### PR TITLE
replaced latest with semver string for coffe-script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node": ">=0.10"
   },
   "dependencies": {
-    "coffee-script": "latest",
+    "coffee-script": ">=1.12.4",
     "underscore": ">=1.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Hello, 

I changed the version for the coffee-script dependency in package.json.
The current value ('latest') makes `npm ls` print annoying error messages:

> npm ERR! missing: coffee-script@latest, required by heterarchy@1.0.7

The proposed change ('>=1.12.4') should have the same effect.

Thanks for the nice package.
